### PR TITLE
add a command to end auctions past their close time

### DIFF
--- a/npl/admin.py
+++ b/npl/admin.py
@@ -49,7 +49,6 @@ class AuctionAdmin(admin.ModelAdmin):
     autocomplete_fields = ['player']
     list_editable = ['active']
 
-
 @admin.register(Event)
 class EventAdmin(VersionAdmin):
     model = Event

--- a/npl/management/commands/end_auctions.py
+++ b/npl/management/commands/end_auctions.py
@@ -1,0 +1,13 @@
+from django.core.management.base import BaseCommand, CommandError
+from django.conf import settings
+from datetime import datetime
+
+from npl import models, utils
+
+
+class Command(BaseCommand):
+    def handle(self, *args, **options):
+        for auction in models.Auction.objects.filter(active=True):
+            if auction.closes.date() < datetime.now():
+                auction.active = False
+                auction.save()


### PR DESCRIPTION
Something simple that sets active auctions to inactive on the backend.

I am also curious about the difference between the admin page's Auctions and Collections tabs. Maybe Auctions can cover active auctions and Collections closed auctions?